### PR TITLE
chore: change manifest to v3

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-	"manifest_version": 2,
+	"manifest_version": 3,
 	"name": "Chrome Minimal Scrollbar",
 	"version": "1.1",
 	"description": "Global CSS scrollbar. No JavaScript. All CSS.",


### PR DESCRIPTION
I love this extension so much, plain and simple, didn't want this to be off webstore due to manifest version deadline (June 2023)
A simple change of version number lol😂. 
Making this change to just to keep this alive.
Thank you.